### PR TITLE
feat : Add filters on /leads and /site-visit page

### DIFF
--- a/app/leads/page.tsx
+++ b/app/leads/page.tsx
@@ -28,10 +28,9 @@ import {
 } from "@/components/ui/sheet"
 
 import { DateRange } from "react-day-picker";
-import { Calendar } from "@/components/ui/calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { CalendarIcon } from "lucide-react";
-import { format } from "date-fns";
+import DateRangePicker from "@/components/dateRangePicker"
+
 
 
 import { DataTable } from "@/components/data-table"
@@ -735,13 +734,13 @@ export default function LeadManagement() {
       if (selectedStatuses.length > 0) parts.push(
         ...selectedStatuses.map(s => s === 'reached' ? 'Reached' : 'Not Reached')
       );
-      return parts.length > 0 ? parts.join(', ') : 'All Types & Statuses';
+      return parts.length > 0 ? parts.join(', ') : 'Filters';
     }, [selectedTypes, selectedStatuses]);
 
     return (
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
-          <Button variant="outline" className="w-[200px] justify-start">
+          <Button variant="outline" className="w-[160px] justify-start">
             {displayValue}
           </Button>
         </PopoverTrigger>
@@ -848,40 +847,7 @@ const filteredLeads = useMemo(() => {
                 />
 
                 <div>
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <Button
-                        id="date"
-                        variant="outline"
-                      className="w-[200px] max-w-[200px] justify-start text-left font-normal truncate"
-                      >
-                        <CalendarIcon className="mr-2 h-4 w-4" />
-                        {dateRange?.from ? (
-                          dateRange.to ? (
-                            <>
-                              {format(dateRange.from, "MMM dd, yyyy")} -{" "}
-                              {format(dateRange.to, "MMM dd, yyyy")}
-                            </>
-                          ) : (
-                            format(dateRange.from, "MMM dd, yyyy")
-                          )
-                        ) : (
-                          <span>Pick a date range</span>
-                        )}
-
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-1" align="center">
-                      <Calendar
-                        initialFocus
-                        mode="range"
-                        defaultMonth={dateRange?.from}
-                        selected={dateRange}
-                        onSelect={setDateRange}
-                        numberOfMonths={1}
-                      />
-                    </PopoverContent>
-                  </Popover>
+                 <DateRangePicker dateRange={dateRange} setDateRange={setDateRange} />
                 </div>
 
 

--- a/app/leads/page.tsx
+++ b/app/leads/page.tsx
@@ -351,64 +351,64 @@ export default function LeadManagement() {
   })
 
 
-  const handleLeadAudioUpdate = (audioUpdate: any) => {
-    console.log('Handling lead audio update:', audioUpdate);
+const handleLeadAudioUpdate = (audioUpdate: any) => {
+  console.log('Handling lead audio update:', audioUpdate);
 
-    // Extract audio data - handle both direct data and nested payload
-    const updateData = audioUpdate.data || audioUpdate.payload || audioUpdate;
-    const { lead_id, audio_data, timestamp } = updateData;
+  // Extract audio data - handle both direct data and nested payload
+  const updateData = audioUpdate.data || audioUpdate.payload || audioUpdate;
+  const { lead_id, audio_data, timestamp } = updateData;
 
-    if (!lead_id || !audio_data) {
-      console.warn('Invalid audio update data:', audioUpdate);
-      return;
+  if (!lead_id || !audio_data) {
+    console.warn('Invalid audio update data:', audioUpdate);
+    return;
+  }
+
+  console.log('Processing audio update for lead:', lead_id);
+
+  // Update the leads list in cache
+  queryClient.setQueryData(['getAllLeads'], (oldData: any) => {
+    if (!oldData?.data) {
+      console.warn('No existing lead data to update with audio');
+      return oldData;
     }
 
-    console.log('Processing audio update for lead:', lead_id);
+    const updatedData = {
+      ...oldData,
+      data: oldData.data.map((lead: any) => {
+        if (lead._id === lead_id || lead.id === lead_id) {
+          console.log('Updating lead with audio data:', lead_id);
+          return {
+            ...lead,
+            call_recording: {
+              ...lead.call_recording,
+              audio_r2_url: audio_data.audio_r2_url,
+              elevenlabs_conversation_id: audio_data.elevenlabs_conversation_id || lead.call_recording?.elevenlabs_conversation_id
+            },
+            audio_data: audio_data
+          };
+        }
+        return lead;
+      })
+    };
 
-    // Update the leads list in cache
-    queryClient.setQueryData(['getAllLeads'], (oldData: any) => {
-      if (!oldData?.data) {
-        console.warn('No existing lead data to update with audio');
-        return oldData;
-      }
+    console.log('Updated leads with audio data for lead:', lead_id);
+    return updatedData;
+  });
 
-      const updatedData = {
-        ...oldData,
-        data: oldData.data.map((lead: any) => {
-          if (lead._id === lead_id || lead.id === lead_id) {
-            console.log('Updating lead with audio data:', lead_id);
-            return {
-              ...lead,
-              call_recording: {
-                ...lead.call_recording,
-                audio_r2_url: audio_data.audio_r2_url,
-                elevenlabs_conversation_id: audio_data.elevenlabs_conversation_id || lead.call_recording?.elevenlabs_conversation_id
-              },
-              audio_data: audio_data
-            };
-          }
-          return lead;
-        })
-      };
-
-      console.log('Updated leads with audio data for lead:', lead_id);
-      return updatedData;
-    });
-
-    // Update selected lead if it's the one being updated
-    if (selectedLead && (selectedLead._id === lead_id || selectedLead.id === lead_id)) {
-      console.log('Updating selected lead with audio data');
-      setSelectedLead(prevLead => ({
-        ...prevLead,
-        call_recording: {
-          ...prevLead.call_recording,
-          audio_r2_url: audio_data.audio_r2_url,
-          elevenlabs_conversation_id: audio_data.elevenlabs_conversation_id || prevLead.call_recording?.elevenlabs_conversation_id,
-        },
-        audio_data: audio_data
-      }));
-    }
-  };
+  // Update selected lead if it's the one being updated
+  if (selectedLead && (selectedLead._id === lead_id || selectedLead.id === lead_id)) {
+    console.log('Updating selected lead with audio data');
+    setSelectedLead(prevLead => ({
+      ...prevLead,
+      call_recording: {
+        ...prevLead.call_recording,
+        audio_r2_url: audio_data.audio_r2_url,
+        elevenlabs_conversation_id: audio_data.elevenlabs_conversation_id || prevLead.call_recording?.elevenlabs_conversation_id,
+      },
+      audio_data: audio_data
+    }));
+  }
+};
 
   const handleNewLeadReceived = (newLead: any) => {
     console.log('Handling new lead:', newLead);

--- a/app/site-visits/page.tsx
+++ b/app/site-visits/page.tsx
@@ -56,6 +56,7 @@ import { DateRange } from "react-day-picker";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { CalendarIcon } from "lucide-react";
 import { Calendar } from "@/components/ui/calendar";
+import DateRangePicker from "@/components/dateRangePicker"
 
 import { format } from "date-fns";
 
@@ -384,40 +385,7 @@ export default function SiteVisitManagement() {
               </div>
               <div className="flex space-x-2">
                 <div>
-                  <Popover>
-                        <PopoverTrigger asChild>
-                          <Button
-                            id="date"
-                            variant="outline"
-                          className="w-[200px] max-w-[200px] justify-start text-left font-normal truncate"
-                          >
-                            <CalendarIcon className="mr-2 h-4 w-4" />
-                            {dateRange?.from ? (
-                              dateRange.to ? (
-                                <>
-                                  {format(dateRange.from, "MMM dd, yyyy")} -{" "}
-                                  {format(dateRange.to, "MMM dd, yyyy")}
-                                </>
-                              ) : (
-                                format(dateRange.from, "MMM dd, yyyy")
-                              )
-                            ) : (
-                              <span>Pick a date range</span>
-                            )}
-  
-                          </Button>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-auto p-1" align="center">
-                          <Calendar
-                            initialFocus
-                            mode="range"
-                            defaultMonth={dateRange?.from}
-                            selected={dateRange}
-                            onSelect={setDateRange}
-                            numberOfMonths={1}
-                          />
-                        </PopoverContent>
-                    </Popover>
+                  <DateRangePicker dateRange={dateRange} setDateRange={setDateRange} />
                 </div>
                 {/* <Button variant="outline" onClick={() => document.getElementById("csv-upload")?.click()}>
                   <Upload className="mr-2 h-4 w-4" />

--- a/app/site-visits/page.tsx
+++ b/app/site-visits/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React from "react"
-import { useEffect, useState } from "react"
+import { useEffect, useState, useMemo } from "react"
 import { useRouter } from "next/navigation"
 import DashboardLayout from "@/components/dashboard-layout"
 import { LeadSkeleton, LoadingScreen, TeamSkeleton } from "@/components/loading-screen"
@@ -23,7 +23,7 @@ import {
   Locate,
   LocateOff,
   Eye,
-  Calendar,
+
   Phone,
   X,
   Flame,
@@ -51,6 +51,13 @@ import {
 
 import { mockSiteVisits } from "@/components/site-visit-list"
 import { useSiteVisits } from "@/hooks/use-site-visits"
+
+import { DateRange } from "react-day-picker";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { CalendarIcon } from "lucide-react";
+import { Calendar } from "@/components/ui/calendar";
+
+import { format } from "date-fns";
 
 interface AddTeamMember {
   username: string;
@@ -268,6 +275,32 @@ export default function SiteVisitManagement() {
   const [editingLead, setEditingLead] = useState<TeamMember | null>(null)
   const [selectedSiteVisit, setSelectedSiteVisit] = useState<any | null>(null)
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+
+
+  const [dateRange, setDateRange] = useState<DateRange | undefined>(undefined);
+
+  const filteredSiteVisits = useMemo(() => {
+    if (!siteVisitsData) return [];
+
+    return siteVisitsData.filter(visit => {
+
+    let dateMatch = true;
+    if (dateRange?.from && dateRange?.to) {
+      const leadDate = new Date(visit.created_at);
+      const fromDate = new Date(dateRange.from);
+      const toDate = new Date(dateRange.to);
+        toDate.setHours(23, 59, 59, 999);
+
+      dateMatch = leadDate >= fromDate && leadDate <= toDate;
+      console.log("dateMatch",dateMatch)
+    }
+    return dateMatch
+  });
+
+  }, [siteVisitsData, dateRange]); 
+
+
+
   const router = useRouter()
 
   useEffect(() => {
@@ -350,6 +383,42 @@ export default function SiteVisitManagement() {
                 <p className="text-gray-600 dark:text-gray-400">Manage all scheduled site visits and meetings</p>
               </div>
               <div className="flex space-x-2">
+                <div>
+                  <Popover>
+                        <PopoverTrigger asChild>
+                          <Button
+                            id="date"
+                            variant="outline"
+                          className="w-[200px] max-w-[200px] justify-start text-left font-normal truncate"
+                          >
+                            <CalendarIcon className="mr-2 h-4 w-4" />
+                            {dateRange?.from ? (
+                              dateRange.to ? (
+                                <>
+                                  {format(dateRange.from, "MMM dd, yyyy")} -{" "}
+                                  {format(dateRange.to, "MMM dd, yyyy")}
+                                </>
+                              ) : (
+                                format(dateRange.from, "MMM dd, yyyy")
+                              )
+                            ) : (
+                              <span>Pick a date range</span>
+                            )}
+  
+                          </Button>
+                        </PopoverTrigger>
+                        <PopoverContent className="w-auto p-1" align="center">
+                          <Calendar
+                            initialFocus
+                            mode="range"
+                            defaultMonth={dateRange?.from}
+                            selected={dateRange}
+                            onSelect={setDateRange}
+                            numberOfMonths={1}
+                          />
+                        </PopoverContent>
+                    </Popover>
+                </div>
                 {/* <Button variant="outline" onClick={() => document.getElementById("csv-upload")?.click()}>
                   <Upload className="mr-2 h-4 w-4" />
                   Export CSV
@@ -374,7 +443,7 @@ export default function SiteVisitManagement() {
             <Tabs defaultValue="list" className="space-y-4">
               <TabsContent value="list" className="space-y-4">
                 <DataTable
-                  data={siteVisitsData} // Replace with your actual site visits data
+                  data={filteredSiteVisits} // Replace with your actual site visits data
                   columns={columns}
                   handleCellClickCb={handleViewSiteVisit}
                   clickableColumns={[

--- a/components/dateRangePicker.tsx
+++ b/components/dateRangePicker.tsx
@@ -1,0 +1,54 @@
+import { FC } from "react";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+import { CalendarIcon } from "lucide-react";
+import { Calendar } from "@/components/ui/calendar";
+import { format } from "date-fns";
+import { DateRange } from "react-day-picker";
+
+interface DateRangePickerProps {
+  dateRange?: DateRange;
+  setDateRange: (range: DateRange | undefined) => void;
+}
+
+const DateRangePicker: FC<DateRangePickerProps> = ({ dateRange, setDateRange }) => {
+  return (
+    <div>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            id="date"
+            variant="outline"
+            className="w-[200px] max-w-[200px] justify-start text-left font-normal truncate"
+          >
+            <CalendarIcon className="mr-2 h-4 w-4" />
+            {dateRange?.from ? (
+              dateRange.to ? (
+                <>
+                  {format(dateRange.from, "MMM dd, yyyy")} -{" "}
+                  {format(dateRange.to, "MMM dd, yyyy")}
+                </>
+              ) : (
+                format(dateRange.from, "MMM dd, yyyy")
+              )
+            ) : (
+              <span>Pick a date range</span>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-1" align="center">
+          <Calendar
+            initialFocus
+            mode="range"
+            defaultMonth={dateRange?.from}
+            selected={dateRange}
+            onSelect={setDateRange}
+            numberOfMonths={1}
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+};
+
+export default DateRangePicker;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: latest
         version: 5.80.2(@tanstack/react-query@5.80.2(react@19.1.0))(react@19.1.0)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.21(postcss@8.5.4)
@@ -125,6 +128,9 @@ importers:
       lucide-react:
         specifier: ^0.454.0
         version: 0.454.0(react@19.1.0)
+      luxon:
+        specifier: ^3.7.1
+        version: 3.7.1
       next:
         specifier: 15.2.4
         version: 15.2.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -143,6 +149,9 @@ importers:
       react-hook-form:
         specifier: ^7.54.1
         version: 7.57.0(react@19.1.0)
+      react-icons:
+        specifier: ^5.5.0
+        version: 5.5.0(react@19.1.0)
       react-resizable-panels:
         specifier: ^2.1.7
         version: 2.1.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1093,6 +1102,17 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
+
   '@types/d3-array@3.2.1':
     resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
 
@@ -1471,6 +1491,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
 
+  luxon@3.7.1:
+    resolution: {integrity: sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==}
+    engines: {node: '>=12'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1637,6 +1661,11 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-icons@5.5.0:
+    resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
+    peerDependencies:
+      react: '*'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -2808,6 +2837,14 @@ snapshots:
       '@tanstack/query-core': 5.80.2
       react: 19.1.0
 
+  '@tanstack/react-table@8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@tanstack/table-core@8.21.3': {}
+
   '@types/d3-array@3.2.1': {}
 
   '@types/d3-color@3.1.3': {}
@@ -3157,6 +3194,8 @@ snapshots:
     dependencies:
       react: 19.1.0
 
+  luxon@3.7.1: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -3299,6 +3338,10 @@ snapshots:
       scheduler: 0.26.0
 
   react-hook-form@7.57.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+
+  react-icons@5.5.0(react@19.1.0):
     dependencies:
       react: 19.1.0
 


### PR DESCRIPTION
This PR introduces filtering capabilities on both the Lead and Site Visits pages:

Lead Page Filters

  1. Lead Type: Filter leads by type (Hot or Cold)
  2. Lead Reached: Filter based on whether the lead has been reached (True or False)
  3. Date Range: Filter leads based on the created_at date within a selected date range

Site Visits Page Filters

  1. Date Range: Filter site visits based on created_at within a selected date range